### PR TITLE
hm-module/plugins: Add Auth Proxy Adapter

### DIFF
--- a/nix/hm-module/plugins/auth-proxy-adapter.nix
+++ b/nix/hm-module/plugins/auth-proxy-adapter.nix
@@ -1,0 +1,15 @@
+{ lib }:
+let
+  inherit (lib) mkOption mkEnableOption types;
+in
+{
+  enabled = mkEnableOption "Auth Proxy Adapter plugin";
+  hostname = mkOption {
+    default = "127.0.0.1";
+    type = types.str;
+  };
+  port = mkOption {
+    default = 4545;
+    type = types.port;
+  };
+}

--- a/nix/hm-module/plugins/default.nix
+++ b/nix/hm-module/plugins/default.nix
@@ -17,6 +17,7 @@ in
             "album-color-theme"
             "ambient-mode"
             "api-server"
+            "auth-proxy-adapter"
             "captions-selector"
             "crossfade"
             "disable-autoplay"


### PR DESCRIPTION
Waiting until `youtube-music` gets bumped to `3.10.X` in nixpkgs 