### PR TITLE
Rename to pear desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# youtube-music-nix
+# pear-desktop-nix
 
-Documentation: https://h-banii.github.io/youtube-music-nix/
+Documentation: https://h-banii.github.io/pear-desktop-nix/
 
 ## Home Manager Module
 
 ```nix
-inputs.youtube-music = {
-    url = "github:h-banii/youtube-music-nix";
+inputs.pear-desktop = {
+    url = "github:h-banii/pear-desktop-nix";
     inputs.nixpkgs.follows = "nixpkgs";
 };
 ```
@@ -15,9 +15,9 @@ inputs.youtube-music = {
 {
     ...
     imports = [
-        inputs.youtube-music.homeManagerModules.default
+        inputs.pear-desktop.homeManagerModules.default
     ];
-    programs.youtube-music = {
+    programs.pear-desktop = {
         enable = true;
         options = {
             tray = true;

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -2,9 +2,9 @@ import { defineConfig } from "vitepress";
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
-  title: "youtube-music-nix",
+  title: "pear-desktop-nix",
   description: "Documentation",
-  base: "/youtube-music-nix/",
+  base: "/pear-desktop-nix/",
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     nav: [{ text: "Home", link: "/" }],
@@ -22,7 +22,7 @@ export default defineConfig({
     socialLinks: [
       {
         icon: "github",
-        link: "https://github.com/h-banii/youtube-music-nix",
+        link: "https://github.com/h-banii/pear-desktop-nix",
       },
     ],
   },

--- a/docs/nix/package.nix
+++ b/docs/nix/package.nix
@@ -8,7 +8,7 @@
   ...
 }:
 buildNpmPackage {
-  pname = "youtube-music-nix-docs";
+  pname = "pear-desktop-nix-docs";
   version = "1.0.0";
 
   patchPhase = ''

--- a/docs/nix/shell.nix
+++ b/docs/nix/shell.nix
@@ -4,7 +4,7 @@
   ...
 }:
 mkShell {
-  name = "youtube-music-nix-docs-dev";
+  name = "pear-desktop-nix-docs-dev";
   packages = [
     nodejs
   ];

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "youtube-music-nix-docs",
+  "name": "pear-desktop-nix-docs",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "youtube-music-nix-docs",
+      "name": "pear-desktop-nix-docs",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "youtube-music-nix-docs",
+  "name": "pear-desktop-nix-docs",
   "version": "1.0.0",
-  "description": "Documentation for the youtube-music Home Manager module",
+  "description": "Documentation for the pear-desktop Home Manager module",
   "main": " ",
   "scripts": {
     "dev": "vitepress dev",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -3,8 +3,8 @@
 layout: home
 
 hero:
-  name: "YouTube Music"
-  text: "th-ch/youtube-music"
+  name: "Pear Desktop"
+  text: "pear-devs/pear-desktop"
   tagline: "Home Manager Module Documentation"
   actions:
     - theme: brand
@@ -16,7 +16,7 @@ features:
     details: "Options documentation"
     link: /pages/home-manager/
   - title: Virtual Machine
-    details: "Run youtube-music in a Virtual Machine"
+    details: "Run pear-desktop in a Virtual Machine"
     link: /pages/virtual-machine
 ---
 

--- a/docs/src/pages/home-manager/options.json
+++ b/docs/src/pages/home-manager/options.json
@@ -1,5 +1,5 @@
 {
-  "programs.youtube-music.enable": {
+  "programs.pear-desktop.enable": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module"
     ],
@@ -7,20 +7,20 @@
       "_type": "literalExpression",
       "text": "false"
     },
-    "description": "Whether to enable YouTube Music.",
+    "description": "Whether to enable Pear Desktop.",
     "example": {
       "_type": "literalExpression",
       "text": "true"
     },
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "enable"
     ],
     "readOnly": false,
     "type": "boolean"
   },
-  "programs.youtube-music.options.alwaysOnTop": {
+  "programs.pear-desktop.options.alwaysOnTop": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/options.nix"
     ],
@@ -31,14 +31,14 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "options",
       "alwaysOnTop"
     ],
     "readOnly": false,
     "type": "unspecified value"
   },
-  "programs.youtube-music.options.appVisible": {
+  "programs.pear-desktop.options.appVisible": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/options.nix"
     ],
@@ -49,14 +49,14 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "options",
       "appVisible"
     ],
     "readOnly": false,
     "type": "unspecified value"
   },
-  "programs.youtube-music.options.autoResetAppCache": {
+  "programs.pear-desktop.options.autoResetAppCache": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/options.nix"
     ],
@@ -67,14 +67,14 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "options",
       "autoResetAppCache"
     ],
     "readOnly": false,
     "type": "unspecified value"
   },
-  "programs.youtube-music.options.autoUpdates": {
+  "programs.pear-desktop.options.autoUpdates": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/options.nix"
     ],
@@ -85,14 +85,14 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "options",
       "autoUpdates"
     ],
     "readOnly": false,
     "type": "unspecified value"
   },
-  "programs.youtube-music.options.customWindowTitle": {
+  "programs.pear-desktop.options.customWindowTitle": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/options.nix"
     ],
@@ -100,17 +100,17 @@
       "_type": "literalExpression",
       "text": "null"
     },
-    "description": "Set window title to this value instead of dynamically changing it to\nthe current song's name.\n\nSee https://github.com/th-ch/youtube-music/pull/3656\n",
+    "description": "Set window title to this value instead of dynamically changing it to\nthe current song's name.\n\nSee https://github.com/th-ch/pear-desktop/pull/3656\n",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "options",
       "customWindowTitle"
     ],
     "readOnly": false,
     "type": "null or string"
   },
-  "programs.youtube-music.options.disableHardwareAcceleration": {
+  "programs.pear-desktop.options.disableHardwareAcceleration": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/options.nix"
     ],
@@ -121,14 +121,14 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "options",
       "disableHardwareAcceleration"
     ],
     "readOnly": false,
     "type": "unspecified value"
   },
-  "programs.youtube-music.options.hideMenu": {
+  "programs.pear-desktop.options.hideMenu": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/options.nix"
     ],
@@ -139,14 +139,14 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "options",
       "hideMenu"
     ],
     "readOnly": false,
     "type": "unspecified value"
   },
-  "programs.youtube-music.options.hideMenuWarned": {
+  "programs.pear-desktop.options.hideMenuWarned": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/options.nix"
     ],
@@ -157,14 +157,14 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "options",
       "hideMenuWarned"
     ],
     "readOnly": false,
     "type": "unspecified value"
   },
-  "programs.youtube-music.options.language": {
+  "programs.pear-desktop.options.language": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/options.nix"
     ],
@@ -175,14 +175,14 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "options",
       "language"
     ],
     "readOnly": false,
     "type": "one of <null>, \"ar\", \"bg\", \"ca\", \"cs\", \"de\", \"el\", \"en\", \"es\", \"et\", \"fa\", \"fi\", \"fil\", \"fr\", \"he\", \"hi\", \"hr\", \"hu\", \"id\", \"is\", \"it\", \"ja\", \"ka\", \"ko\", \"lt\", \"ms\", \"nb\", \"ne\", \"nl\", \"pl\", \"pt-BR\", \"pt\", \"ro\", \"ru\", \"si\", \"sl\", \"sv\", \"th\", \"tr\", \"uk\", \"ur\", \"vi\", \"zh-CN\", \"zh-TW\""
   },
-  "programs.youtube-music.options.likeButtons": {
+  "programs.pear-desktop.options.likeButtons": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/options.nix"
     ],
@@ -193,14 +193,14 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "options",
       "likeButtons"
     ],
     "readOnly": false,
     "type": "one of \"\", \"force\", \"hide\""
   },
-  "programs.youtube-music.options.overrideUserAgent": {
+  "programs.pear-desktop.options.overrideUserAgent": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/options.nix"
     ],
@@ -211,14 +211,14 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "options",
       "overrideUserAgent"
     ],
     "readOnly": false,
     "type": "unspecified value"
   },
-  "programs.youtube-music.options.proxy": {
+  "programs.pear-desktop.options.proxy": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/options.nix"
     ],
@@ -229,14 +229,14 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "options",
       "proxy"
     ],
     "readOnly": false,
     "type": "unspecified value"
   },
-  "programs.youtube-music.options.removeUpgradeButton": {
+  "programs.pear-desktop.options.removeUpgradeButton": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/options.nix"
     ],
@@ -247,14 +247,14 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "options",
       "removeUpgradeButton"
     ],
     "readOnly": false,
     "type": "unspecified value"
   },
-  "programs.youtube-music.options.restartOnConfigChanges": {
+  "programs.pear-desktop.options.restartOnConfigChanges": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/options.nix"
     ],
@@ -265,14 +265,14 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "options",
       "restartOnConfigChanges"
     ],
     "readOnly": false,
     "type": "unspecified value"
   },
-  "programs.youtube-music.options.resumeOnStart": {
+  "programs.pear-desktop.options.resumeOnStart": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/options.nix"
     ],
@@ -283,14 +283,14 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "options",
       "resumeOnStart"
     ],
     "readOnly": false,
     "type": "unspecified value"
   },
-  "programs.youtube-music.options.startAtLogin": {
+  "programs.pear-desktop.options.startAtLogin": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/options.nix"
     ],
@@ -301,14 +301,14 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "options",
       "startAtLogin"
     ],
     "readOnly": false,
     "type": "unspecified value"
   },
-  "programs.youtube-music.options.startingPage": {
+  "programs.pear-desktop.options.startingPage": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/options.nix"
     ],
@@ -319,14 +319,14 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "options",
       "startingPage"
     ],
     "readOnly": false,
     "type": "one of \"\", \"Default\", \"Home\", \"Explore\", \"New Releases\", \"Charts\", \"Moods & Genres\", \"Library\", \"Playlists\", \"Songs\", \"Albums\", \"Artists\", \"Subscribed Artists\", \"Uploads\", \"Uploaded Playlists\", \"Uploaded Songs\", \"Uploaded Albums\", \"Uploaded Artists\""
   },
-  "programs.youtube-music.options.themes": {
+  "programs.pear-desktop.options.themes": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/options.nix"
     ],
@@ -337,14 +337,14 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "options",
       "themes"
     ],
     "readOnly": false,
     "type": "list of absolute path"
   },
-  "programs.youtube-music.options.tray": {
+  "programs.pear-desktop.options.tray": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/options.nix"
     ],
@@ -355,14 +355,14 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "options",
       "tray"
     ],
     "readOnly": false,
     "type": "unspecified value"
   },
-  "programs.youtube-music.options.trayClickPlayPause": {
+  "programs.pear-desktop.options.trayClickPlayPause": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/options.nix"
     ],
@@ -373,14 +373,14 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "options",
       "trayClickPlayPause"
     ],
     "readOnly": false,
     "type": "unspecified value"
   },
-  "programs.youtube-music.options.usePodcastParticipantAsArtist": {
+  "programs.pear-desktop.options.usePodcastParticipantAsArtist": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/options.nix"
     ],
@@ -391,31 +391,31 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "options",
       "usePodcastParticipantAsArtist"
     ],
     "readOnly": false,
     "type": "unspecified value"
   },
-  "programs.youtube-music.package": {
+  "programs.pear-desktop.package": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module"
     ],
     "default": {
       "_type": "literalExpression",
-      "text": "pkgs.youtube-music"
+      "text": "pkgs.pear-desktop"
     },
-    "description": "The youtube-music package to use.",
+    "description": "The pear-desktop package to use.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "package"
     ],
     "readOnly": false,
     "type": "package"
   },
-  "programs.youtube-music.plugins.adblocker.additionalBlockLists": {
+  "programs.pear-desktop.plugins.adblocker.additionalBlockLists": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/plugins"
     ],
@@ -426,7 +426,7 @@
     "description": "Additional list of filters to use",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "plugins",
       "adblocker",
       "additionalBlockLists"
@@ -434,7 +434,7 @@
     "readOnly": false,
     "type": "list of string"
   },
-  "programs.youtube-music.plugins.adblocker.blocker": {
+  "programs.pear-desktop.plugins.adblocker.blocker": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/plugins"
     ],
@@ -445,7 +445,7 @@
     "description": "Which adblocker to use",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "plugins",
       "adblocker",
       "blocker"
@@ -453,7 +453,7 @@
     "readOnly": false,
     "type": "one of \"With blocklists\", \"In player\", \"Ad speedup\""
   },
-  "programs.youtube-music.plugins.adblocker.cache": {
+  "programs.pear-desktop.plugins.adblocker.cache": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/plugins"
     ],
@@ -464,7 +464,7 @@
     "description": "When enabled, the adblocker will cache the blocklists",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "plugins",
       "adblocker",
       "cache"
@@ -472,7 +472,7 @@
     "readOnly": false,
     "type": "unspecified value"
   },
-  "programs.youtube-music.plugins.adblocker.disableDefaultLists": {
+  "programs.pear-desktop.plugins.adblocker.disableDefaultLists": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/plugins"
     ],
@@ -487,7 +487,7 @@
     },
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "plugins",
       "adblocker",
       "disableDefaultLists"
@@ -495,7 +495,7 @@
     "readOnly": false,
     "type": "boolean"
   },
-  "programs.youtube-music.plugins.adblocker.enable": {
+  "programs.pear-desktop.plugins.adblocker.enable": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/plugins"
     ],
@@ -510,7 +510,7 @@
     },
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "plugins",
       "adblocker",
       "enable"
@@ -518,7 +518,7 @@
     "readOnly": false,
     "type": "boolean"
   },
-  "programs.youtube-music.plugins.album-actions.enable": {
+  "programs.pear-desktop.plugins.album-actions.enable": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/plugins"
     ],
@@ -533,7 +533,7 @@
     },
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "plugins",
       "album-actions",
       "enable"
@@ -541,7 +541,7 @@
     "readOnly": false,
     "type": "boolean"
   },
-  "programs.youtube-music.plugins.album-color-theme.enable": {
+  "programs.pear-desktop.plugins.album-color-theme.enable": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/plugins"
     ],
@@ -556,7 +556,7 @@
     },
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "plugins",
       "album-color-theme",
       "enable"
@@ -564,7 +564,7 @@
     "readOnly": false,
     "type": "boolean"
   },
-  "programs.youtube-music.plugins.album-color-theme.ratio": {
+  "programs.pear-desktop.plugins.album-color-theme.ratio": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/plugins"
     ],
@@ -575,7 +575,7 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "plugins",
       "album-color-theme",
       "ratio"
@@ -583,7 +583,7 @@
     "readOnly": false,
     "type": "unspecified value"
   },
-  "programs.youtube-music.plugins.ambient-mode.blur": {
+  "programs.pear-desktop.plugins.ambient-mode.blur": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/plugins"
     ],
@@ -594,7 +594,7 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "plugins",
       "ambient-mode",
       "blur"
@@ -602,7 +602,7 @@
     "readOnly": false,
     "type": "one of 0, 5, 10, 25, 50, 100, 150, 200, 500"
   },
-  "programs.youtube-music.plugins.ambient-mode.buffer": {
+  "programs.pear-desktop.plugins.ambient-mode.buffer": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/plugins"
     ],
@@ -613,7 +613,7 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "plugins",
       "ambient-mode",
       "buffer"
@@ -621,7 +621,7 @@
     "readOnly": false,
     "type": "one of 1, 5, 10, 20, 30"
   },
-  "programs.youtube-music.plugins.ambient-mode.enable": {
+  "programs.pear-desktop.plugins.ambient-mode.enable": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/plugins"
     ],
@@ -636,7 +636,7 @@
     },
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "plugins",
       "ambient-mode",
       "enable"
@@ -644,7 +644,7 @@
     "readOnly": false,
     "type": "boolean"
   },
-  "programs.youtube-music.plugins.ambient-mode.fullscreen": {
+  "programs.pear-desktop.plugins.ambient-mode.fullscreen": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/plugins"
     ],
@@ -655,7 +655,7 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "plugins",
       "ambient-mode",
       "fullscreen"
@@ -663,7 +663,7 @@
     "readOnly": false,
     "type": "unspecified value"
   },
-  "programs.youtube-music.plugins.ambient-mode.interpolationTime": {
+  "programs.pear-desktop.plugins.ambient-mode.interpolationTime": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/plugins"
     ],
@@ -674,7 +674,7 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "plugins",
       "ambient-mode",
       "interpolationTime"
@@ -682,7 +682,7 @@
     "readOnly": false,
     "type": "one of 0, 500, 1000, 1500, 2000, 3000, 4000, 5000"
   },
-  "programs.youtube-music.plugins.ambient-mode.opacity": {
+  "programs.pear-desktop.plugins.ambient-mode.opacity": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/plugins"
     ],
@@ -693,7 +693,7 @@
     "description": "Value between 0.0 and 1.0",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "plugins",
       "ambient-mode",
       "opacity"
@@ -701,7 +701,7 @@
     "readOnly": false,
     "type": "integer or floating point number between 0 and 1 (both inclusive)"
   },
-  "programs.youtube-music.plugins.ambient-mode.quality": {
+  "programs.pear-desktop.plugins.ambient-mode.quality": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/plugins"
     ],
@@ -712,7 +712,7 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "plugins",
       "ambient-mode",
       "quality"
@@ -720,7 +720,7 @@
     "readOnly": false,
     "type": "one of 10, 25, 50, 100, 200, 500, 1000"
   },
-  "programs.youtube-music.plugins.ambient-mode.size": {
+  "programs.pear-desktop.plugins.ambient-mode.size": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/plugins"
     ],
@@ -731,7 +731,7 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "plugins",
       "ambient-mode",
       "size"
@@ -739,7 +739,7 @@
     "readOnly": false,
     "type": "one of 100, 110, 125, 150, 175, 200, 300"
   },
-  "programs.youtube-music.plugins.amuse.enable": {
+  "programs.pear-desktop.plugins.amuse.enable": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/plugins"
     ],
@@ -754,7 +754,7 @@
     },
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "plugins",
       "amuse",
       "enable"
@@ -762,7 +762,7 @@
     "readOnly": false,
     "type": "boolean"
   },
-  "programs.youtube-music.plugins.api-server.authStrategy": {
+  "programs.pear-desktop.plugins.api-server.authStrategy": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/plugins"
     ],
@@ -773,7 +773,7 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "plugins",
       "api-server",
       "authStrategy"
@@ -781,14 +781,14 @@
     "readOnly": false,
     "type": "one of \"AUTH_AT_FIRST\", \"NONE\""
   },
-  "programs.youtube-music.plugins.visualizer.wave.animations.*.type": {
+  "programs.pear-desktop.plugins.visualizer.wave.animations.*.type": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module/plugins"
     ],
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "plugins",
       "visualizer",
       "wave",
@@ -799,7 +799,7 @@
     "readOnly": false,
     "type": "string"
   },
-  "programs.youtube-music.url": {
+  "programs.pear-desktop.url": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module"
     ],
@@ -810,13 +810,13 @@
     "description": "This option has no description.",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "url"
     ],
     "readOnly": false,
     "type": "unspecified value"
   },
-  "programs.youtube-music.version": {
+  "programs.pear-desktop.version": {
     "declarations": [
       "/nix/store/r5cqvarv2zngbkpw03jh7c0cvdgrdi2z-source/nix/hm-module"
     ],
@@ -827,7 +827,7 @@
     "description": "Version used in migrations",
     "loc": [
       "programs",
-      "youtube-music",
+      "pear-desktop",
       "version"
     ],
     "readOnly": false,

--- a/docs/src/pages/introduction.md
+++ b/docs/src/pages/introduction.md
@@ -1,8 +1,8 @@
 # Introduction
 
 ```nix
-inputs.youtube-music = {
-    url = "github:h-banii/youtube-music-nix";
+inputs.pear-desktop = {
+    url = "github:h-banii/pear-desktop-nix";
     inputs.nixpkgs.follows = "nixpkgs";
 };
 ```
@@ -11,9 +11,9 @@ inputs.youtube-music = {
 {
     ...
     imports = [
-        inputs.youtube-music.homeManagerModules.default
+        inputs.pear-desktop.homeManagerModules.default
     ];
-    programs.youtube-music = {
+    programs.pear-desktop = {
         enable = true;
         options = {
             tray = true;

--- a/nix/hm-module/default.nix
+++ b/nix/hm-module/default.nix
@@ -11,6 +11,7 @@ let
     mkOption
     mkEnableOption
     mkPackageOption
+    mkRenamedOptionModule
     ;
   inherit (lib.attrsets) mapAttrs' mapAttrsRecursiveCond nameValuePair;
 
@@ -29,7 +30,7 @@ let
     in
     recurse [ ] set;
 
-  toYouTubeMusicJSON =
+  toPearDesktopJSON =
     opts: cfg:
     let
       # This is done to avoid "obsolete option" warnings:
@@ -54,13 +55,13 @@ let
     );
 
   inherit (lib.attrsets) filterAttrsRecursive;
-  cfg = config.programs.youtube-music;
+  cfg = config.programs.pear-desktop;
 
   generatedConfig =
     let
-      opts = options.programs.youtube-music;
-      jsonOptions = toYouTubeMusicJSON opts.options cfg.options;
-      jsonPlugins = toYouTubeMusicJSON opts.plugins cfg.plugins;
+      opts = options.programs.pear-desktop;
+      jsonOptions = toPearDesktopJSON opts.options cfg.options;
+      jsonPlugins = toPearDesktopJSON opts.plugins cfg.plugins;
       configText = ''
         "url": "${cfg.url}",
         "options": ${jsonOptions},
@@ -73,7 +74,7 @@ let
       '';
     in
     rec {
-      package = pkgs.writeText "youtube-music-config.json" ''
+      package = pkgs.writeText "pear-desktop-config.json" ''
         {
           ${configText},
           "__nix__": {
@@ -85,20 +86,28 @@ let
     };
 in
 {
-  options.programs.youtube-music = {
-    enable = mkEnableOption "YouTube Music";
-    package = mkPackageOption pkgs "youtube-music" { };
+  options.programs.pear-desktop = {
+    enable = mkEnableOption "Pear Desktop";
+
+    package = mkPackageOption pkgs "pear-desktop" { };
+
     url = mkOption { default = "https://music.youtube.com"; };
+
     version = mkOption {
       description = "Version used in migrations";
       default = "3.11.0";
       internal = true;
     };
+
+    # TODO: Check for changes on this option on the next release
+    #
+    # this is the `productName` in `package.json` (probably)
     configFolderName = mkOption {
       description = "Name of the config folder";
       default = "YouTube Music";
       internal = true;
     };
+
     configFileName = mkOption {
       description = "Name of the config file";
       default = "config.json";
@@ -109,12 +118,22 @@ in
   imports = [
     ./options.nix
     ./plugins
+    (mkRenamedOptionModule
+      [
+        "programs"
+        "youtube-music"
+      ]
+      [
+        "programs"
+        "pear-desktop"
+      ]
+    )
   ];
 
   config = mkIf cfg.enable {
     home.packages = [ cfg.package ];
 
-    home.activation.updateYouTubeMusicConfig =
+    home.activation.updatePearDesktopConfig =
       let
         jq = lib.getExe pkgs.jq;
       in

--- a/nix/hm-module/options.nix
+++ b/nix/hm-module/options.nix
@@ -3,7 +3,7 @@ let
   inherit (lib) mkOption types;
 in
 {
-  options.programs.youtube-music.options = {
+  options.programs.pear-desktop.options = {
     language = mkOption {
       default = null;
       type = types.enum [
@@ -141,7 +141,7 @@ in
         Set window title to this value instead of dynamically changing it to
         the current song's name.
 
-        See https://github.com/th-ch/youtube-music/pull/3656
+        See https://github.com/th-ch/pear-desktop/pull/3656
       '';
       default = null;
       type = types.nullOr types.str;

--- a/nix/hm-module/plugins/default.nix
+++ b/nix/hm-module/plugins/default.nix
@@ -55,7 +55,7 @@ let
 
   pluginOptionPathBase = [
     "programs"
-    "youtube-music"
+    "pear-desktop"
     "plugins"
   ];
 
@@ -129,7 +129,7 @@ in
     )
   ];
 
-  options.programs.youtube-music.plugins =
+  options.programs.pear-desktop.plugins =
     mergeAttrs
       (listToAttrs (
         map (plugin: {

--- a/nix/hm-module/plugins/discord.nix
+++ b/nix/hm-module/plugins/discord.nix
@@ -17,8 +17,9 @@ in
     default = 10 * 60 * 1000;
     type = types.number;
   };
+  # TODO: Check if this needs renaming on the next release
   playOnYouTubeMusic = mkEnableOption "" // {
-    description = ''Add a "Play on YouTube Music" button to rich presence'';
+    description = ''Add a "Play on Pear Desktop" button to rich presence'';
   };
   hideGitHubButton = mkEnableOption "" // {
     description = ''Hide the "View App On GitHub" button in the rich presence'';

--- a/nix/hm-module/plugins/scrobbler.nix
+++ b/nix/hm-module/plugins/scrobbler.nix
@@ -5,7 +5,7 @@ in
 {
   enable = mkEnableOption "Scrobbler plugin";
   scrobbleOtherMedia = mkEnableOption "" // {
-    description = "Attempt to scrobble other video types (e.g. Podcasts, normal YouTube videos)";
+    description = "Attempt to scrobble other video types (e.g. Podcasts, normal videos)";
     default = true;
   };
   alternativeTitles = mkEnableOption "" // {

--- a/vm/configuration/default.nix
+++ b/vm/configuration/default.nix
@@ -1,6 +1,6 @@
 {
   pkgs,
-  youtube-music,
+  pear-desktop,
   modulesPath,
   lib,
   ...
@@ -11,7 +11,7 @@
     "flakes"
   ];
 
-  networking.hostName = "youtube-music";
+  networking.hostName = "pear-desktop";
 
   imports = [
     (modulesPath + "/profiles/minimal.nix")
@@ -39,7 +39,7 @@
   programs.hyprland.enable = true;
 
   environment.systemPackages = [
-    youtube-music
+    pear-desktop
   ];
 
   system.stateVersion = "24.05";

--- a/vm/configuration/home.nix
+++ b/vm/configuration/home.nix
@@ -17,7 +17,7 @@
         ];
         bind = [
           "$mod, T, exec, kitty"
-          "$mod, M, exec, youtube-music"
+          "$mod, M, exec, pear-desktop"
           "$mod, C, killactive"
         ];
         bindm = [

--- a/vm/flake.nix
+++ b/vm/flake.nix
@@ -21,22 +21,22 @@
     {
       legacyPackages.${system} =
         let
-          default-system = self.lib.mkYtmSystem {
-            youtube-music = nixpkgs.legacyPackages.${system}.youtube-music;
+          default-system = self.lib.mkSystem {
+            inherit (nixpkgs.legacyPackages.${system}) pear-desktop;
           };
         in
         default-system.config.system.build;
 
       lib = {
-        mkYtmSystem =
+        mkSystem =
           {
-            youtube-music,
+            pear-desktop,
             extraModules ? [ ],
           }:
           nixpkgs.lib.nixosSystem {
             inherit system;
             specialArgs = {
-              inherit youtube-music;
+              inherit pear-desktop;
               inherit home-manager;
             };
             modules = [ ./configuration ] ++ extraModules;


### PR DESCRIPTION
This repo was also renamed to `pear-desktop-nix`, to match upstream
```nix
inputs.pear-desktop.url = "github:h-banii/pear-desktop-nix";
```