### PR TITLE
hm-module: 3.11.0 -> 3.12.0

### DIFF
--- a/nix/hm-module/default.nix
+++ b/nix/hm-module/default.nix
@@ -68,7 +68,7 @@ in
 
     version = mkOption {
       description = "Version used in migrations";
-      default = "3.11.0";
+      default = "3.12.0";
       internal = true;
     };
 

--- a/nix/hm-module/options.nix
+++ b/nix/hm-module/options.nix
@@ -111,6 +111,9 @@ in
         "hide"
       ];
     };
+    swapLikeButtonsOrder = mkEnableOption "" // {
+      description = "Whether to swap the like buttons order";
+    };
     proxy = mkOption {
       default = "";
       description = "Proxy uri";

--- a/nix/hm-module/plugins/album-color-theme.nix
+++ b/nix/hm-module/plugins/album-color-theme.nix
@@ -9,4 +9,5 @@ in
     description = "Color mix ratio";
     type = types.number;
   };
+  enableSeekbar = mkEnableOption "seek bar";
 }

--- a/nix/hm-module/plugins/api-server.nix
+++ b/nix/hm-module/plugins/api-server.nix
@@ -32,4 +32,15 @@ in
     type = types.listOf types.str;
     internal = true;
   };
+  useHttps = mkEnableOption "HTTPS support";
+  certPath = mkOption {
+    description = "string path to HTTPS certificate";
+    type = types.str;
+    default = "";
+  };
+  keyPath = mkOption {
+    description = "path to HTTPS key";
+    type = types.str;
+    default = "";
+  };
 }

--- a/nix/hm-module/plugins/clock.nix
+++ b/nix/hm-module/plugins/clock.nix
@@ -1,0 +1,11 @@
+{ lib, ... }:
+let
+  inherit (lib) mkEnableOption;
+in
+{
+  enable = mkEnableOption "Clock plugin";
+  displaySeconds = mkEnableOption "" // {
+    description = "Whether to display seconds";
+  };
+  hour12 = mkEnableOption "12-hour clock";
+}

--- a/nix/hm-module/plugins/default.nix
+++ b/nix/hm-module/plugins/default.nix
@@ -65,13 +65,38 @@ let
     "plugins"
   ];
 
-  renamedEnableOptions = builtins.map (
-    pluginName:
-    let
-      optionName = baseOptionName ++ [ pluginName ];
-    in
-    mkRenamedOptionModule (optionName ++ [ "enabled" ]) (optionName ++ [ "enable" ])
-  ) ((builtins.attrNames simplePlugins) ++ complexPlugins);
+  renamedEnableOptions =
+    builtins.map
+      (
+        pluginName:
+        let
+          optionName = baseOptionName ++ (lib.lists.flatten [ pluginName ]);
+        in
+        mkRenamedOptionModule (optionName ++ [ "enabled" ]) (optionName ++ [ "enable" ])
+      )
+      (
+        (builtins.attrNames simplePlugins)
+        ++ complexPlugins
+        ++ [
+          [
+
+            "scrobbler"
+            "scrobblers"
+            "lastfm"
+          ]
+          [
+
+            "scrobbler"
+            "scrobblers"
+            "listenbrainz"
+          ]
+          [
+
+            "downloader"
+            "downloadOnFinish"
+          ]
+        ]
+      );
 in
 {
   imports = renamedEnableOptions ++ [
@@ -84,64 +109,6 @@ in
       ]
     ) "")
     (mkRenamedOptionModule (baseOptionName ++ [ "adblocker" ]) (baseOptionName ++ [ "do-not-track" ]))
-    (mkRenamedOptionModule
-      (
-        baseOptionName
-        ++ [
-          "scrobbler"
-          "scrobblers"
-          "lastfm"
-          "enabled"
-        ]
-      )
-      (
-        baseOptionName
-        ++ [
-          "scrobbler"
-          "scrobblers"
-          "lastfm"
-          "enable"
-        ]
-      )
-    )
-    (mkRenamedOptionModule
-      (
-        baseOptionName
-        ++ [
-          "scrobbler"
-          "scrobblers"
-          "listenbrainz"
-          "enabled"
-        ]
-      )
-      (
-        baseOptionName
-        ++ [
-          "scrobbler"
-          "scrobblers"
-          "listenbrainz"
-          "enable"
-        ]
-      )
-    )
-    (mkRenamedOptionModule
-      (
-        baseOptionName
-        ++ [
-          "downloader"
-          "downloadOnFinish"
-          "enabled"
-        ]
-      )
-      (
-        baseOptionName
-        ++ [
-          "downloader"
-          "downloadOnFinish"
-          "enable"
-        ]
-      )
-    )
   ];
 
   options.programs.pear-desktop.plugins =

--- a/nix/hm-module/plugins/default.nix
+++ b/nix/hm-module/plugins/default.nix
@@ -4,7 +4,6 @@ let
   inherit (builtins) listToAttrs map;
 
   complexPlugins = [
-    "adblocker"
     "album-color-theme"
     "ambient-mode"
     "api-server"
@@ -15,6 +14,7 @@ let
     "custom-output-device"
     "disable-autoplay"
     "discord"
+    "do-not-track"
     "downloader"
     "equalizer"
     "in-app-menu"
@@ -70,6 +70,7 @@ let
 in
 {
   imports = renamedEnableOptions ++ [
+    (mkRenamedOptionModule (baseOptionName ++ [ "adblocker" ]) (baseOptionName ++ [ "do-not-track" ]))
     (mkRenamedOptionModule
       (
         baseOptionName

--- a/nix/hm-module/plugins/default.nix
+++ b/nix/hm-module/plugins/default.nix
@@ -10,6 +10,7 @@ let
     "api-server"
     "auth-proxy-adapter"
     "captions-selector"
+    "clock"
     "crossfade"
     "custom-output-device"
     "disable-autoplay"

--- a/nix/hm-module/plugins/default.nix
+++ b/nix/hm-module/plugins/default.nix
@@ -1,6 +1,11 @@
 { lib, pkgs, ... }:
 let
-  inherit (lib) mkEnableOption mkRenamedOptionModule mergeAttrs;
+  inherit (lib)
+    mkEnableOption
+    mkRenamedOptionModule
+    mkRemovedOptionModule
+    mergeAttrs
+    ;
   inherit (builtins) listToAttrs map;
 
   complexPlugins = [
@@ -70,6 +75,14 @@ let
 in
 {
   imports = renamedEnableOptions ++ [
+    (mkRemovedOptionModule (
+      baseOptionName
+      ++ [
+        "visualizer"
+        "butterchurn"
+        "renderingFrequencyInMs"
+      ]
+    ) "")
     (mkRenamedOptionModule (baseOptionName ++ [ "adblocker" ]) (baseOptionName ++ [ "do-not-track" ]))
     (mkRenamedOptionModule
       (

--- a/nix/hm-module/plugins/default.nix
+++ b/nix/hm-module/plugins/default.nix
@@ -54,25 +54,25 @@ let
     performance-improvement = "Performance Improvement plugin";
   };
 
-  pluginOptionPathBase = [
+  baseOptionName = [
     "programs"
     "pear-desktop"
     "plugins"
   ];
 
-  renamedOptions = builtins.map (
+  renamedEnableOptions = builtins.map (
     pluginName:
     let
-      pluginOptionPath = pluginOptionPathBase ++ [ pluginName ];
+      optionName = baseOptionName ++ [ pluginName ];
     in
-    mkRenamedOptionModule (pluginOptionPath ++ [ "enabled" ]) (pluginOptionPath ++ [ "enable" ])
+    mkRenamedOptionModule (optionName ++ [ "enabled" ]) (optionName ++ [ "enable" ])
   ) ((builtins.attrNames simplePlugins) ++ complexPlugins);
 in
 {
-  imports = renamedOptions ++ [
+  imports = renamedEnableOptions ++ [
     (mkRenamedOptionModule
       (
-        pluginOptionPathBase
+        baseOptionName
         ++ [
           "scrobbler"
           "scrobblers"
@@ -81,7 +81,7 @@ in
         ]
       )
       (
-        pluginOptionPathBase
+        baseOptionName
         ++ [
           "scrobbler"
           "scrobblers"
@@ -92,7 +92,7 @@ in
     )
     (mkRenamedOptionModule
       (
-        pluginOptionPathBase
+        baseOptionName
         ++ [
           "scrobbler"
           "scrobblers"
@@ -101,7 +101,7 @@ in
         ]
       )
       (
-        pluginOptionPathBase
+        baseOptionName
         ++ [
           "scrobbler"
           "scrobblers"
@@ -112,7 +112,7 @@ in
     )
     (mkRenamedOptionModule
       (
-        pluginOptionPathBase
+        baseOptionName
         ++ [
           "downloader"
           "downloadOnFinish"
@@ -120,7 +120,7 @@ in
         ]
       )
       (
-        pluginOptionPathBase
+        baseOptionName
         ++ [
           "downloader"
           "downloadOnFinish"

--- a/nix/hm-module/plugins/discord.nix
+++ b/nix/hm-module/plugins/discord.nix
@@ -17,7 +17,6 @@ in
     default = 10 * 60 * 1000;
     type = types.number;
   };
-  # TODO: Check if this needs renaming on the next release
   playOnYouTubeMusic = mkEnableOption "" // {
     description = ''Add a "Play on Pear Desktop" button to rich presence'';
   };

--- a/nix/hm-module/plugins/do-not-track.nix
+++ b/nix/hm-module/plugins/do-not-track.nix
@@ -13,7 +13,6 @@ in
     type = types.enum [
       "With blocklists"
       "In player"
-      "Ad speedup"
     ];
     default = "In player";
   };
@@ -22,7 +21,7 @@ in
     type = types.listOf types.str;
     default = [ ];
   };
-  disableDefaultLists = mkEnableOption null // {
+  disableDefaultLists = mkEnableOption "" // {
     description = "Whether to disable the default blocklists";
   };
 }

--- a/nix/hm-module/plugins/transparent-player.nix
+++ b/nix/hm-module/plugins/transparent-player.nix
@@ -16,7 +16,7 @@ in
       "tabbed"
       "none"
     ];
-    default = "acrylic";
+    default = "none";
     description = "Transparent player's material type";
   };
 }

--- a/nix/hm-module/plugins/visualizer.nix
+++ b/nix/hm-module/plugins/visualizer.nix
@@ -26,11 +26,6 @@ in
       type = types.str;
       internal = true;
     };
-    renderingFrequencyInMs = mkOption {
-      default = 500;
-      type = types.number;
-      internal = true;
-    };
     blendTimeInSeconds = mkOption {
       default = 2.7;
       type = types.number;


### PR DESCRIPTION
This adds new options from `3.12.0`

(pear-desktop on nixpkgs is still on version `3.11.0` though)

edit: nixpkgs PR tracker https://nixpk.gs/pr-tracker.html?pr=536379